### PR TITLE
Adds south_migrations to installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=[
         "postmark",
         "postmark.migrations",
+        "postmark.south_migrations",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Old South migrations were correctly moved to `south_migrations`, but the package wasn't installed when `pip install`ing, preventing Django<=1.6 from doing `python manage.py migrate`.